### PR TITLE
Add aws-crt-client benchmark

### DIFF
--- a/test/sdk-benchmarks/pom.xml
+++ b/test/sdk-benchmarks/pom.xml
@@ -190,6 +190,18 @@
              <groupId>org.eclipse.jetty.http2</groupId>
              <artifactId>http2-hpack</artifactId>
          </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.3.14</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <version>${awsjavasdk.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
+++ b/test/sdk-benchmarks/src/main/java/software/amazon/awssdk/benchmark/apicall/httpclient/async/AwsCrtClientBenchmark.java
@@ -1,0 +1,124 @@
+package software.amazon.awssdk.benchmark.apicall.httpclient.async;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import software.amazon.awssdk.benchmark.apicall.httpclient.SdkHttpClientBenchmark;
+import software.amazon.awssdk.benchmark.utils.MockServer;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonAsyncClient;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static software.amazon.awssdk.benchmark.utils.BenchmarkConstant.CONCURRENT_CALLS;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.awaitCountdownLatchUninterruptibly;
+import static software.amazon.awssdk.benchmark.utils.BenchmarkUtils.countDownUponCompletion;
+
+/**
+ * Using aws-crt-client to test against local mock https server.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 15, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(2) // To reduce difference between each run
+@BenchmarkMode(Mode.Throughput)
+public class AwsCrtClientBenchmark implements SdkHttpClientBenchmark {
+
+    private MockServer mockServer;
+    private SdkAsyncHttpClient sdkHttpClient;
+    private ProtocolRestJsonAsyncClient client;
+    private TlsContextOptions tlsOptions;
+    private TlsContext tlsContext;
+    private SocketOptions socketOptions;
+    private ClientBootstrap bootstrap;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        mockServer = new MockServer();
+        mockServer.start();
+
+        int numCores = Runtime.getRuntime().availableProcessors();
+        bootstrap = new ClientBootstrap(numCores);
+        socketOptions = new SocketOptions();
+
+        tlsOptions = new TlsContextOptions();
+        tlsOptions.setVerifyPeer(false);
+        tlsContext = new TlsContext(tlsOptions);
+
+        sdkHttpClient = AwsCrtAsyncHttpClient.builder()
+                .bootstrap(bootstrap)
+                .socketOptions(socketOptions)
+                .tlsContext(tlsContext)
+                .build();
+
+        client = ProtocolRestJsonAsyncClient.builder()
+                .endpointOverride(mockServer.getHttpsUri())
+                .httpClient(sdkHttpClient)
+                .build();
+
+        // Making sure the request actually succeeds
+        client.allTypes().join();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        mockServer.stop();
+        client.close();
+        sdkHttpClient.close();
+        tlsContext.close();
+        tlsOptions.close();
+        socketOptions.close();
+        bootstrap.close();
+    }
+
+    @Override
+    @Benchmark
+    @OperationsPerInvocation(CONCURRENT_CALLS)
+    public void concurrentApiCall(Blackhole blackhole) {
+        CountDownLatch countDownLatch = new CountDownLatch(CONCURRENT_CALLS);
+        for (int i = 0; i < CONCURRENT_CALLS; i++) {
+            countDownUponCompletion(blackhole, client.allTypes(), countDownLatch);
+        }
+
+        awaitCountdownLatchUninterruptibly(countDownLatch, 10, TimeUnit.SECONDS);
+
+    }
+
+    @Override
+    @Benchmark
+    public void sequentialApiCall(Blackhole blackhole) {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        countDownUponCompletion(blackhole, client.allTypes(), countDownLatch);
+        awaitCountdownLatchUninterruptibly(countDownLatch, 1, TimeUnit.SECONDS);
+    }
+
+    public static void main(String... args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(AwsCrtClientBenchmark.class.getSimpleName())
+                .addProfiler(StackProfiler.class)
+                .build();
+        Collection<RunResult> run = new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a benchmark based on the pattern used in other Http client benchmarks.

## Motivation and Context
This is useful for testing the performance of the new crt http client and getting profiling data.

## Testing
Benchmark runs:
```
# Run progress: 0.00% complete, ETA 00:06:20
# Fork: 1 of 2
# Warmup Iteration   1: 2019-08-28 03:10:26.354:INFO::software.amazon.awssdk.benchmark.apicall.httpclient.async.AwsCrtClientBenchmark.concurrentApiCall-jmh-worker-1: Logging initialized @310ms to org.eclipse.jetty.util.log.StdErrLog
2691.334 ops/s
# Warmup Iteration   2: 2917.221 ops/s
# Warmup Iteration   3: 3027.850 ops/s
Iteration   1: 3096.794 ops/s
Iteration   2: 3034.292 ops/s
Iteration   3: 2939.297 ops/s
Iteration   4: 2873.485 ops/s
Iteration   5: 2832.959 ops/s
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document
- [X] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license
